### PR TITLE
Use ES5 syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@
 
 module.exports = makeAbortable;
 
-function makeAbortable(promise, { signal }) {
+function makeAbortable(promise, opts) {
+  var signal = opts.signal;
   if (signal.aborted) {
     return Promise.reject(createAbortError());
   }
@@ -19,7 +20,7 @@ function makeAbortable(promise, { signal }) {
 }
 
 function createAbortError() {
-  let abortError;
+  var abortError;
 
   try {
     abortError = new DOMException('Aborted', 'AbortError');


### PR DESCRIPTION
Some toolchains don't transpile dependencies by default, meaning this package breaks builds. Using ES5 everywhere enables this package to be used in more contexts.